### PR TITLE
Mocks should support the multi:true option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Books.mock({name: 'untitled'}, null, {name: {$in: ['untitled']}})
 var changedDocs = myCollection.mockMulti([{name: 'john'}, {name: 'john'}], [{name: 'john'}, {$set: {selected: true}}, {multi: true}])
 // inserts two identical documents, performs an update which affects both documents and returns all the affected documents.
 ```
+
+### mock vs mockMulti
+
+The `mock` and `mockMulti` both simulate the result of mongo db operations against your collection, but are subtly different, here's a quick run down of when to use which:
+
+1. You should generally use the mock method, especially for allow/deny rules and other cases where you know that only one document will be affected (or you only care about one document).
+2. You should use the mockMulti method to test the behavior of update operations which may affect multiple documents
+3. You should use the mockMulti method with caution on the server, it will load all affected documents into memory!
+
 ### How it works
 
 **The `mock` method takes three arguments:**
@@ -38,21 +47,19 @@ var changedDocs = myCollection.mockMulti([{name: 'john'}, {name: 'john'}], [{nam
 The mock method executes insert, then update, and finally findOne and returns the result of findOne.
 
 Each argument is optional and we have some smart behavior to handle non-existant arguments:
-- `insert`, if not specified we'll grab the first part of the `update` operator
+- `insert`, if not specified we'll grab the first part of the `update` operator as a query and insert the first doc which matches that query
 - `update`, if not specified we'll skip the update, if a single argument is specified, we'll use the id returned by our insert operation as the first argument (the query)
 - `find`, if not specified we'll use the id returned by our insert operation
 
 **The `mockMulti` method takes four arguments:**
 
-- `insert` an array of arguments to be passed to the mockCollection's insert method
+- `insert` an array of documents to be inserted in the mock collection, you can also pass an array of arrays if you want more control over which arguments are passed to the insert method.
 - `update` an array of arguments to be passed to the mockCollection's update method
-- `flags` an object to be passed to the mockCollection's update method
 - `find` an array of arguments to be passed to the mockCollection's find method
 
 The mockMulti method executes insert, then update, and finally find and returns the result of find().fetch().
 
 Each argument is optional:
-- `insert`, if not specified we'll grab the first part of the `update` operator
+- `insert`, if not specified we'll grab the first part of the `update` operator as a query and insert all the found documents into our mock collection
 - `update`, if not specified we'll skip the update, if a single argument is specified, we'll use the ids returned by our insert operation as the first argument (the query)
-- `flags`, if not specified we'll just do the update as usual
 - `find`, if not specified we'll use the ids returned by our insert operation

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This package adds a method to Mongo.Collection's prototype that mocks the result
 **This is a work in progress.**
 
 ### Installation
-Simply add the `useful:collection-mocks` package to your meteor app and you can start using the `mock` method on your collections.
+Simply add the `useful:collection-mocks` package to your meteor app and you can start using the `mock` and `mockMulti` methods on your collections.
 
 ### Examples
 ```
@@ -15,7 +15,7 @@ Books.mock({name: 'Leave it to Jeeves'}, {$set: {author: 'PGWoodhouse'}})
 
 ```
 Books.mock(null, [{author: 'PGWoodhouse'}, {$set: {rating: 5}}])
-// -> if a book with author 'PGWoodhouse' exists, we'll return that book with the updated rating
+// if a book with author 'PGWoodhouse' exists, we'll return that book with the updated rating
 ```
 
 ```
@@ -23,9 +23,13 @@ Books.mock({name: 'untitled'}, null, {name: {$in: ['untitled']}})
 // -> {name: 'untitled'}
 ```
 
+```
+var changedDocs = myCollection.mockMulti([{name: 'john'}, {name: 'john'}], [{name: 'john'}, {$set: {selected: true}}, {multi: true}])
+// inserts two identical documents, performs an update which affects both documents and returns all the affected documents.
+```
 ### How it works
 
-The mock method takes three arguments:
+**The `mock` method takes three arguments:**
 
 - `insert` an array of arguments to be passed to the mockCollection's insert method
 - `update` an array of arguments to be passed to the mockCollection's update method
@@ -33,7 +37,22 @@ The mock method takes three arguments:
 
 The mock method executes insert, then update, and finally findOne and returns the result of findOne.
 
-Each argument is optional and we have some smart behavior to handle non-existant arguments
+Each argument is optional and we have some smart behavior to handle non-existant arguments:
 - `insert`, if not specified we'll grab the first part of the `update` operator
 - `update`, if not specified we'll skip the update, if a single argument is specified, we'll use the id returned by our insert operation as the first argument (the query)
 - `find`, if not specified we'll use the id returned by our insert operation
+
+**The `mockMulti` method takes four arguments:**
+
+- `insert` an array of arguments to be passed to the mockCollection's insert method
+- `update` an array of arguments to be passed to the mockCollection's update method
+- `flags` an object to be passed to the mockCollection's update method
+- `find` an array of arguments to be passed to the mockCollection's find method
+
+The mockMulti method executes insert, then update, and finally find and returns the result of find().fetch().
+
+Each argument is optional:
+- `insert`, if not specified we'll grab the first part of the `update` operator
+- `update`, if not specified we'll skip the update, if a single argument is specified, we'll use the ids returned by our insert operation as the first argument (the query)
+- `flags`, if not specified we'll just do the update as usual
+- `find`, if not specified we'll use the ids returned by our insert operation

--- a/collection-mocks-tests.js
+++ b/collection-mocks-tests.js
@@ -1,33 +1,67 @@
 // Tests if mock object property gets set when using the insert argument
-Tinytest.add('Mock Collection - insert argument - property gets set correctly', function (test) {
+Tinytest.add('mock method - insert argument - property gets set correctly', function (test) {
   var TestCollection = new Mongo.Collection('test1');
   var mock = TestCollection.mock({ name: 'joe' });
   test.equal(mock.name, 'joe');
 });
 
 // Tests if mock object property gets set when using the update argument
-Tinytest.add('Mock Collection - update argument - property gets set correctly', function (test) {
+Tinytest.add('mock method - update argument - property gets set correctly', function (test) {
   var TestCollection = new Mongo.Collection('test2');
   var mock = TestCollection.mock({ name: 'joe' }, { $set: { read: true } });
   test.equal(mock.read, true);
 }); 
 
-Tinytest.add('Mock Collection - update argument - property gets overriden', function (test) {
+Tinytest.add('mock method - update argument - property gets overriden', function (test) {
   var TestCollection = new Mongo.Collection('test3');
   var mock = TestCollection.mock({ name: 'joe', read: true }, { $set: { read: false } });
   test.equal(mock.read, false);
 }); 
 
 // Tests if mock object property gets set when using the find argument
-Tinytest.add('Mock Collection - find argument - object exists', function (test) {
+Tinytest.add('mock method - find argument - object exists', function (test) {
   var TestCollection = new Mongo.Collection('test4');
   var mock = TestCollection.mock({ name: 'joe', key: 'abc' }, null, { key: 'abc' });
   test.equal(mock.name, 'joe');
 }); 
 
-Tinytest.add('Mock Collection - find argument - object does not exist', function (test) {
+Tinytest.add('mock method - find argument - object does not exist', function (test) {
   var TestCollection = new Mongo.Collection('test5');
   var mock = TestCollection.mock({ name: 'joe', key: 'abc' }, null, { key: 'xyz' });
-  
   test.equal(mock, undefined);
+});
+
+// Tests if mockMulti can insert multiple documents
+Tinytest.add('mockMulti method - insert argument - multiple documents are inserted', function (test) {
+  var TestCollection = new Mongo.Collection('test6');
+  var mocks = TestCollection.mockMulti([{ name:'john' }, { name:'jim' }, { name: 'joe' }]);
+  test.length(mocks, 3);
+  test.equal(mocks[0].name, 'john');
+  test.equal(mocks[1].name, 'jim');
+  test.equal(mocks[2].name, 'joe');
+});
+
+// Tests if mockMulti updates all documents only when multi flag is passed
+Tinytest.add('mockMulti method - update argument - without multi flag', function (test) {
+  var TestCollection = new Mongo.Collection('test7');
+  var mocks = TestCollection.mockMulti([{ name:'john' }, { name:'jim' }], { $set: { updated: true } });
+  test.equal(mocks[0].updated, true);
+  test.isUndefined(mocks[1].updated);
+});
+
+Tinytest.add('mockMulti method - update argument - with multi flag', function (test) {
+  var TestCollection = new Mongo.Collection('test8');
+  var mocks = TestCollection.mockMulti([{ name:'john' }, { name:'jim' }], { $set: { updated: true } }, { multi: true });
+  test.equal(mocks[0].updated, true);
+  test.equal(mocks[1].updated, true);
+});
+
+// Tests if mockMulti returns an array of documents
+Tinytest.add('mockMulti method - find argument - result is array of documents', function (test) {
+  var TestCollection = new Mongo.Collection('test9');
+  var mocks = TestCollection.mockMulti([{ name:'john' }, { name:'jim' }], { $set: { updated: true } }, { multi: true }, { updated: true });
+  test.length(mocks, 2);
+  _.each(mocks, function(doc) { 
+    test.equal(doc.updated, true);
+  })
 });

--- a/collection-mocks-tests.js
+++ b/collection-mocks-tests.js
@@ -1,39 +1,39 @@
 // Tests if mock object property gets set when using the insert argument
 Tinytest.add('mock method - insert argument - property gets set correctly', function (test) {
-  var TestCollection = new Mongo.Collection('test1');
+  var TestCollection = new Mongo.Collection(null);
   var mock = TestCollection.mock({ name: 'joe' });
   test.equal(mock.name, 'joe');
 });
 
 // Tests if mock object property gets set when using the update argument
 Tinytest.add('mock method - update argument - property gets set correctly', function (test) {
-  var TestCollection = new Mongo.Collection('test2');
+  var TestCollection = new Mongo.Collection(null);
   var mock = TestCollection.mock({ name: 'joe' }, { $set: { read: true } });
   test.equal(mock.read, true);
 }); 
 
 Tinytest.add('mock method - update argument - property gets overriden', function (test) {
-  var TestCollection = new Mongo.Collection('test3');
+  var TestCollection = new Mongo.Collection(null);
   var mock = TestCollection.mock({ name: 'joe', read: true }, { $set: { read: false } });
   test.equal(mock.read, false);
 }); 
 
 // Tests if mock object property gets set when using the find argument
 Tinytest.add('mock method - find argument - object exists', function (test) {
-  var TestCollection = new Mongo.Collection('test4');
+  var TestCollection = new Mongo.Collection(null);
   var mock = TestCollection.mock({ name: 'joe', key: 'abc' }, null, { key: 'abc' });
   test.equal(mock.name, 'joe');
 }); 
 
 Tinytest.add('mock method - find argument - object does not exist', function (test) {
-  var TestCollection = new Mongo.Collection('test5');
+  var TestCollection = new Mongo.Collection(null);
   var mock = TestCollection.mock({ name: 'joe', key: 'abc' }, null, { key: 'xyz' });
   test.equal(mock, undefined);
 });
 
 // Tests if mockMulti can insert multiple documents
 Tinytest.add('mockMulti method - insert argument - multiple documents are inserted', function (test) {
-  var TestCollection = new Mongo.Collection('test6');
+  var TestCollection = new Mongo.Collection(null);
   var mocks = TestCollection.mockMulti([{ name:'john' }, { name:'jim' }, { name: 'joe' }]);
   test.length(mocks, 3);
   test.equal(mocks[0].name, 'john');
@@ -43,25 +43,53 @@ Tinytest.add('mockMulti method - insert argument - multiple documents are insert
 
 // Tests if mockMulti updates all documents only when multi flag is passed
 Tinytest.add('mockMulti method - update argument - without multi flag', function (test) {
-  var TestCollection = new Mongo.Collection('test7');
-  var mocks = TestCollection.mockMulti([{ name:'john' }, { name:'jim' }], { $set: { updated: true } });
+  var TestCollection = new Mongo.Collection(null);
+  var mocks = TestCollection.mockMulti([{ name:'john' }, { name:'jim' }], [{}, { $set: { updated: true } }]);
   test.equal(mocks[0].updated, true);
   test.isUndefined(mocks[1].updated);
 });
 
 Tinytest.add('mockMulti method - update argument - with multi flag', function (test) {
-  var TestCollection = new Mongo.Collection('test8');
-  var mocks = TestCollection.mockMulti([{ name:'john' }, { name:'jim' }], { $set: { updated: true } }, { multi: true });
+  var TestCollection = new Mongo.Collection(null);
+  var mocks = TestCollection.mockMulti([{ name:'john' }, { name:'jim' }], [{}, { $set: { updated: true } }, { multi: true }]);
+  test.equal(mocks[0].updated, true);
+  test.equal(mocks[1].updated, true);
+});
+
+Tinytest.add('mockMulti method - update argument - with update query', function (test) {
+  var TestCollection = new Mongo.Collection(null);
+  var mocks = TestCollection.mockMulti([{ name:'john' }, { name:'jim' }], [{name: 'jim'}, { $set: { updated: true } }, { multi: true }], {updated: true});
+
+  test.equal(mocks.length, 1);
+  test.equal(mocks[0].name, 'jim');
+  test.equal(mocks[0].updated, true);
+});
+
+Tinytest.add('mockMulti method - update argument - without insert', function (test) {
+  var TestCollection = new Mongo.Collection(null);
+  TestCollection.insert({name: 'john'});
+  TestCollection.insert({name: 'jim'});
+  var mocks = TestCollection.mockMulti(null, [{}, { $set: { updated: true } }, { multi: true }], {updated: true});
+
+  test.equal(mocks.length, 2);
   test.equal(mocks[0].updated, true);
   test.equal(mocks[1].updated, true);
 });
 
 // Tests if mockMulti returns an array of documents
 Tinytest.add('mockMulti method - find argument - result is array of documents', function (test) {
-  var TestCollection = new Mongo.Collection('test9');
-  var mocks = TestCollection.mockMulti([{ name:'john' }, { name:'jim' }], { $set: { updated: true } }, { multi: true }, { updated: true });
+  var TestCollection = new Mongo.Collection(null);
+  var mocks = TestCollection.mockMulti([{ name:'john' }, { name:'jim' }], [{}, { $set: { updated: true } }, { multi: true }], { updated: true });
   test.length(mocks, 2);
   _.each(mocks, function(doc) { 
     test.equal(doc.updated, true);
   })
+});
+
+Tinytest.addAsync('mockMulti method - insert argument - multiple arguments are supported', function (test, done) {
+  var TestCollection = new Mongo.Collection(null);
+  var didNotice = false;
+  var notice = function () { test.isTrue(true); done(); };
+  var mocks = TestCollection.mockMulti([[{name: 'joe'}, notice]]);
+  test.length(mocks, 1);
 });

--- a/collection-mocks.js
+++ b/collection-mocks.js
@@ -63,3 +63,78 @@ Mongo.Collection.prototype.mock = function (insert, update, find) {
   // return the results of the findOne method
   return findResult;
 };
+
+/**
+ * @summary The mockMulti method. It differs from mock in that the insert operation accepts an array, and the find operation returns find().fetch()
+ * @locus Anywhere
+ * @method mockMulti
+ * @memberOf Mongo.Collection
+ * @param {Array} insert An array of arguments to be passed to the mockCollection's insert method
+ * @param {Array} update An array of arguments to be passed to the mockCollection's update method
+ * @param {Array} find An array of arguments to be passed to the mockCollection's findOne method
+ * @return {Object} The result of findOne
+ */
+// XXX should we merge mockMulti with mock since there is a lot of overlapping code?
+Mongo.Collection.prototype.mockMulti = function (insert, update, flags, find) {
+  var self = this;
+
+  // clear out the mock collection in case any previous calls failed to clean
+  // up after themselves
+  mockCollection.remove({});
+  
+  // if the user doesn't pass an insert argument, lets try to find the document
+  // they're trying to update by searching the real collection (self)
+  if (! insert) {
+    if (! _.isArray(update))
+      throw new Error("implicit insert requires two update arguments");
+    insert = self.findOne(update[0]);
+  }
+  
+  // insert is actually the array of arguments to be passed to the
+  // insert method, but we don't want to force users to call mock with
+  // an array if they don't want to
+  if (! _.isArray(insert)) {
+    insert = [insert];
+  }
+
+  // insert the documents into the mock collection
+  var insertResults = [];
+  if (insert && insert[0]) {
+    // bulk insert does not work in meteor so we need to save all the inserted documents
+    _.each(insert, function(doc) { 
+      // the doc needs to be passed to insert as an array
+      insertResults.push(mockCollection.insert.apply(mockCollection, [doc]));
+    })
+  }
+
+  // since there are more than 1 documents inserted we will use the $in operator to construct our selector
+  var insertResult = { _id: { $in: insertResults } };
+
+  // just like insert, update is the array of arguments that we pass to the
+  // update method; we use the insertResults array as the query selector
+  if (update) {
+    if (! _.isArray(update)) {
+      update = [insertResult, update];
+      // if we have a valid flags argument we should pass it to the update method
+      // XXX should we just give the app developer the option to pass a boolean 'multi' param instead?
+      if (flags) {
+        update.push(flags);
+      }
+    }
+    mockCollection.update.apply(mockCollection, update);
+  }
+
+  // use the document we just inserted if no find argument exists
+  if (! find) find = insertResult;
+
+  // Make sure we pass an array to find
+  if (! _.isArray(find)) {
+    find = [find];
+  }
+
+  // find the document in the mock collection
+  var findResult = mockCollection.find.apply(mockCollection, find).fetch();
+
+  // return the fetched results
+  return findResult;
+};

--- a/collection-mocks.js
+++ b/collection-mocks.js
@@ -70,8 +70,9 @@ Mongo.Collection.prototype.mock = function (insert, update, find) {
  * @method mockMulti
  * @memberOf Mongo.Collection
  * @param {Array} insert An array of arguments to be passed to the mockCollection's insert method
- * @param {Array} update An array of arguments to be passed to the mockCollection's update method
- * @param {Array} find An array of arguments to be passed to the mockCollection's findOne method
+ * @param {Object | Array} update An array of arguments to be passed to the mockCollection's update method
+ * @param {Object} flags An object to be passed to the mockCollection's update method (e.g. { multi: true })
+ * @param {Object | Array} find An array of arguments to be passed to the mockCollection's find method
  * @return {Object} The result of findOne
  */
 // XXX should we merge mockMulti with mock since there is a lot of overlapping code?

--- a/package.js
+++ b/package.js
@@ -15,6 +15,8 @@ Package.onUse(function(api) {
 
 Package.onTest(function(api) {
   api.use('tinytest');
+  api.use('mongo');
+  
   api.use('useful:collection-mocks');
   api.addFiles('collection-mocks-tests.js');
 });


### PR DESCRIPTION
The new mockMulti method can insert an array of documents and update them all when the `multi:true` flag is used. The method returns the results of find().fetch().
